### PR TITLE
Fixed url

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The OpenShift Applier is a playbook implemented in the `openshift-applier` proje
 
 ```console
 $ cd ..
-$ git clone https://github.com:redhat-cop/openshift-applier.git
+$ git clone https://github.com/redhat-cop/openshift-applier.git
 ...
 ```
 


### PR DESCRIPTION
Came across this, when running the old command it would throw:
fatal: unable to access 'https://github.com:redhat-cop/openshift-applier.git/': Port number ended with 'r'